### PR TITLE
warning plus import for db migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,9 @@ To create the first tier it's similar, you just replace `create_superuser` for `
 
 ### 4.4 Database Migrations
 
+> \[!WARNING\]
+> To create the tables if you did not create the endpoints, ensure that you import the models in src/app/models/__init__.py. This step is crucial to create the new tables.
+
 If you are using the db in docker, you need to change this in `docker-compose.yml` to run migrations:
 
 ```sh
@@ -718,6 +721,9 @@ class EntityDelete(SQLModel):
 ```
 
 ### 5.5 Alembic Migrations
+
+> \[!WARNING\]
+> To create the tables if you did not create the endpoints, ensure that you import the models in src/app/models/__init__.py. This step is crucial to create the new models.
 
 Then, while in the `src` folder, run Alembic migrations:
 

--- a/src/app/core/setup.py
+++ b/src/app/core/setup.py
@@ -27,7 +27,7 @@ from .config import (
 )
 from .db.database import async_engine as engine
 from .utils import cache, queue, rate_limit
-
+from ..models import *
 
 # -------------- database --------------
 async def create_tables() -> None:

--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -1,0 +1,4 @@
+from .post import Post
+from .rate_limit import RateLimit
+from .tier import Tier
+from .user import User


### PR DESCRIPTION
> \[!WARNING\]
> To create the tables if you did not create the endpoints, ensure that you import the models in src/app/models/__init__.py. This step is crucial to create the new models.