### PR TITLE
feat(sqlite): support

### DIFF
--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -35,18 +35,6 @@ class SQLiteSettings(DatabaseSettings):
     SQLITE_ASYNC_PREFIX: str = config("SQLITE_ASYNC_PREFIX", default="sqlite+aiosqlite:///")
 
 
-class MySQLSettings(DatabaseSettings):
-    MYSQL_USER: str = config("MYSQL_USER", default="username")
-    MYSQL_PASSWORD: str = config("MYSQL_PASSWORD", default="password")
-    MYSQL_SERVER: str = config("MYSQL_SERVER", default="localhost")
-    MYSQL_PORT: int = config("MYSQL_PORT", default=5432)
-    MYSQL_DB: str = config("MYSQL_DB", default="dbname")
-    MYSQL_URI: str = f"{MYSQL_USER}:{MYSQL_PASSWORD}@{MYSQL_SERVER}:{MYSQL_PORT}/{MYSQL_DB}"
-    MYSQL_SYNC_PREFIX: str = config("MYSQL_SYNC_PREFIX", default="mysql://")
-    MYSQL_ASYNC_PREFIX: str = config("MYSQL_ASYNC_PREFIX", default="mysql+aiomysql://")
-    MYSQL_URL: str = config("MYSQL_URL", default=None)
-
-
 class PostgresSettings(DatabaseSettings):
     POSTGRES_USER: str = config("POSTGRES_USER", default="postgres")
     POSTGRES_PASSWORD: str = config("POSTGRES_PASSWORD", default="postgres")
@@ -105,13 +93,24 @@ class EnvironmentOption(Enum):
     PRODUCTION = "production"
 
 
+class DBOption(Enum):
+    POSTGRES = "postgres"
+    SQLITE = "sqlite"
+
+
 class EnvironmentSettings(BaseSettings):
     ENVIRONMENT: EnvironmentOption = config("ENVIRONMENT", default="local")
+    DB_ENGINE: DBOption = config("DB_ENGINE", default="sqlite")
+
+
+db_type = PostgresSettings
+if config("DB_ENGINE", default="sqlite") == "sqlite":
+    db_type = SQLiteSettings
 
 
 class Settings(
     AppSettings,
-    PostgresSettings,
+    db_type,
     CryptSettings,
     FirstUserSettings,
     TestSettings,

--- a/src/app/core/db/database.py
+++ b/src/app/core/db/database.py
@@ -2,12 +2,16 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.ext.asyncio.session import AsyncSession
 from sqlalchemy.orm import sessionmaker
 
-from ..config import settings
+from ..config import settings, DBOption
 
-
-DATABASE_URI = settings.POSTGRES_URI
-DATABASE_PREFIX = settings.POSTGRES_ASYNC_PREFIX
-DATABASE_URL = f"{DATABASE_PREFIX}{DATABASE_URI}"
+if settings.DB_ENGINE == DBOption.SQLITE:
+    DATABASE_URI = settings.SQLITE_URI
+    DATABASE_PREFIX = settings.SQLITE_ASYNC_PREFIX
+    DATABASE_URL = f"{DATABASE_PREFIX}{DATABASE_URI}"
+if settings.DB_ENGINE == DBOption.POSTGRES:
+    DATABASE_URI = settings.POSTGRES_URI
+    DATABASE_PREFIX = settings.POSTGRES_ASYNC_PREFIX
+    DATABASE_URL = f"{DATABASE_PREFIX}{DATABASE_URI}"
 
 async_engine = create_async_engine(DATABASE_URL, echo=False, future=True)
 

--- a/src/app/core/setup.py
+++ b/src/app/core/setup.py
@@ -91,14 +91,15 @@ def lifespan_factory(
         if isinstance(settings, DatabaseSettings) and create_tables_on_start:
             await create_tables()
 
-        if isinstance(settings, RedisCacheSettings):
-            await create_redis_cache_pool()
+        if settings.ENVIRONMENT != EnvironmentOption.LOCAL:
+            if isinstance(settings, RedisCacheSettings):
+                await create_redis_cache_pool()
 
-        if isinstance(settings, RedisQueueSettings):
-            await create_redis_queue_pool()
+            if isinstance(settings, RedisQueueSettings):
+                await create_redis_queue_pool()
 
-        if isinstance(settings, RedisRateLimiterSettings):
-            await create_redis_rate_limit_pool()
+            if isinstance(settings, RedisRateLimiterSettings):
+                await create_redis_rate_limit_pool()
 
         yield
 

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional
-from uuid import uuid4
+import uuid as uuid_pkg
 
 from sqlmodel import SQLModel, Field
 from pydantic import validator
@@ -19,6 +19,7 @@ class User(UserBase, table=True):
     is_superuser: bool = Field(default=False)
     tier_id: Optional[int] = Field(default=None, foreign_key="tier.id")
     created_at: datetime = Field(default_factory=lambda: datetime.now(datetime.timezone.utc))
+    uuid: uuid_pkg.UUID = Field(default_factory=uuid_pkg.uuid4, primary_key=True)
     updated_at: Optional[datetime] = None
     deleted_at: Optional[datetime] = None
     is_deleted: bool = Field(default=False)


### PR DESCRIPTION
Right now there is:

* configuration for mysql and sqlite but there isn't any code or way to use them
* there is no way to turn off redis 

So:

* Removed the mysql configuration (but can be reinserted if there is code also for that for sure)
* Added a new env value to set the DB engine
* Redis is not loaded if the environmeant is local, as per development cache is not so much useful...