### PR TITLE
Updated Dockerfile to have `export` plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.11 as requirements-stage
 
 WORKDIR /tmp
 
-RUN pip install poetry==1.8.1
+RUN pip install poetry poetry-plugin-export
 
 COPY ./pyproject.toml ./poetry.lock* /tmp/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.11 as requirements-stage
 
 WORKDIR /tmp
 
-RUN pip install poetry
+RUN pip install poetry==1.8.1
 
 COPY ./pyproject.toml ./poetry.lock* /tmp/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ license = "MIT"
 readme = "README.md"
 packages = [{ include = "src" }]
 
+[tool.poetry.requires-plugins]
+poetry-plugin-export = ">=1.8"
+
 [tool.poetry.dependencies]
 python = "^3.11"
 python-dotenv = "^1.0.0"


### PR DESCRIPTION
```
 => [worker requirements-stage 3/5] RUN pip install poetry                                                                                                                                    6.0s
 => [web requirements-stage 4/5] COPY ./pyproject.toml ./poetry.lock* /tmp/                                                                                                                   0.0s
 => ERROR [worker requirements-stage 5/5] RUN poetry export -f requirements.txt --output requirements.txt --without-hashes                                                                    0.3s
------
 > [worker requirements-stage 5/5] RUN poetry export -f requirements.txt --output requirements.txt --without-hashes:
0.246 
0.246 The command "export" does not exist.
```

Looks like the `export` command [is no longer installed with Poetry](https://python-poetry.org/docs/cli/#export) by default

Added it to the pip command in docker to make this work (And added it as a dependency to the `pyproject.toml`)