### PR TITLE
chore: fixing docker compose minor warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # --------- requirements ---------
 
-FROM python:3.11 as requirements-stage
+FROM python:3.11 AS requirements-stage
 
 WORKDIR /tmp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   web:
     build:


### PR DESCRIPTION
# Fixes
- According to docker documentation, Version is no more used and is obsolete in compose file. 
- Docker Compose logged warnings for case matching in docker file instructions.